### PR TITLE
rename rex file and add remedial action file to be deleted

### DIFF
--- a/cypress/integration/core/valid/us-run-core-process-acceptance-test.js
+++ b/cypress/integration/core/valid/us-run-core-process-acceptance-test.js
@@ -115,7 +115,8 @@ describe('Test behaviour of run button', () => {
                 '/gridcapa/CORE/VALID/artifacts/20210723_0030_2D5_CGM_0_9.xiidm',
                 '/gridcapa/CORE/VALID/artifacts/raoParameters.json',
                 '/gridcapa/CORE/VALID/artifacts/crac_2021-07-22T22:30Z.json',
-                '/gridcapa/CORE/VALID/outputs/20210723-00-ValidationCORE-v0.csv'
+                '/gridcapa/CORE/VALID/outputs/20210723-00-ValidationCORE-REX-v0.csv',
+                '/gridcapa/CORE/VALID/outputs/20210723-00-RemedialActions-REX-v0.csv'
             ]);
         });
         ftp.runOnFtp(fbUser, fbPassword, () => {
@@ -126,7 +127,8 @@ describe('Test behaviour of run button', () => {
                 '/sftp/core/valid/glsks/20210723-F226-v1.xml',
                 '/sftp/core/valid/refprogs/20210723-F110.xml',
                 '/sftp/core/valid/studypoints/20210723-Points_Etude-v01.csv',
-                '/sftp/core/valid/outputs/20210723-00-ValidationCORE-v0.csv'
+                '/sftp/core/valid/outputs/20210723-00-ValidationCORE-REX-v0.csv',
+                '/gridcapa/CORE/VALID/outputs/20210723-00-RemedialActions-REX-v0.csv'
             ]);
         });
     })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Update of a test following release of gridcapa-core-valid:0.4.0


**What is the current behavior?** *(You can also link to an open issue here)*
At the end of a test, the "MAIN" result file is deleted


**What is the new behavior (if this is a feature change)?**
With the introduction of the distinction of automatic and manual tasks, the acceptance test now deletes both REX and REMEDIAL_ACTION results file.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No